### PR TITLE
Move anchors with images.

### DIFF
--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -78,6 +78,10 @@ define("tinymce/util/Quirks", [
 					selection.select(e.target);
 				}
 
+				if (e.target.tagName == 'IMG' && e.target.parentNode.tagName == 'A') {
+					selection.select(e.target.parentNode);
+				}
+
 				selectionHtml = editor.selection.getContent();
 
 				// Safari/IE doesn't support custom dataTransfer items so we can only use URL and Text


### PR DESCRIPTION
This fixes an issue with anchors that wrap images being lost during the drag & drop event. More information can be found in the original bug report at https://core.trac.wordpress.org/ticket/28272